### PR TITLE
#BF. Correct for dimension mismatch between target_shape and image.baseshape

### DIFF
--- a/surfa/image/framed.py
+++ b/surfa/image/framed.py
@@ -518,7 +518,7 @@ class FramedImage(FramedArray):
         if np.array_equal(self.baseshape, shape):
             return self.copy() if copy else self
 
-        delta = (np.array(shape) - np.array(self.baseshape)) / 2
+        delta = (np.array(shape[:3]) - np.array(self.baseshape)) / 2
         low = np.floor(delta).astype(int)
         high = np.ceil(delta).astype(int)
 


### PR DESCRIPTION
Without this fix _mri_sclimbic_seg_ thrown a "ValueError: operands could not be broadcast together with shapes (4,) (3,)"