### PR TITLE
Make version-checking compatible with updated Packaging library.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools.extension import Extension
 
 dist.Distribution().fetch_build_eggs(['packaging', 'cython', 'numpy'])
 
-import packaging.version
+from packaging.version import InvalidVersion, parse
 import numpy as np
 from Cython.Build import cythonize
 
@@ -50,7 +50,9 @@ match = re.search(pattern, init_text, re.M)
 if not match:
     raise RuntimeError(f'Unable to find __version__ in {init_file}.')
 version = match.group(1)
-if isinstance(packaging.version.parse(version), packaging.version.LegacyVersion):
+try:
+    version_obj = parse(version)
+except InvalidVersion:
     raise RuntimeError(f'Invalid version string {version}.')
 
 long_description = '''Surfa is a collection of Python (3.5+) utilities for medical image


### PR DESCRIPTION
Recently the `packaging` library removed the `LegacyVersion` class after nearly two years of deprecation warning [1]. This has resulted in Surfa's `setup.py` script throwing the following error at installation time:
`AttributeError: module 'packaging.version' has no attribute 'LegacyVersion'`

Proposed fix: 
Instead of checking if the (parsed) `version` string is a `LegacyVersion` object, use the `packaging.version.parse(version)` function to parse the `version` string and catch any `InvalidVersion` exception. If an exception is raised, then its not a valid `version` string according to the PEP 440 specification.

[1] https://github.com/pypa/packaging/issues/530