### PR TITLE
fixed vox2vxm transform calculation

### DIFF
--- a/surfa/transform/geometry.py
+++ b/surfa/transform/geometry.py
@@ -337,11 +337,11 @@ class ImageGeometry:
     @property
     def vox2vxm(self):
         # voxel morph centers the col,row,slice
-        M = np.eye(4);
-        M[0][3] = (self._shape[0]-1)/2;
-        M[1][3] = (self._shape[1]-1)/2;
-        M[2][3] = (self._shape[2]-1)/2;
-        return(Affine(M));
+        M = np.eye(4)
+        M[0][3] = (self._shape[0]-1)/2 * -1
+        M[1][3] = (self._shape[1]-1)/2 * -1
+        M[2][3] = (self._shape[2]-1)/2 * -1
+        return(Affine(M))
 
     @property
     def vxm2vox(self):


### PR DESCRIPTION
According to Yael, the direction of the shift for center based voxelmorph coordinates was backwards. Multiplied shift by -1