### PR TITLE
support mgz warp

### DIFF
--- a/surfa/core/framed.py
+++ b/surfa/core/framed.py
@@ -5,6 +5,18 @@ from surfa.core.array import conform_ndim
 from surfa.core.labels import LabelLookup
 
 
+# mgz now has its intent encoded in the version number
+# version = (intent & 0xff ) << 8) | MGH_VERSION
+# MGH_VERSION = 1
+class FramedArrayIntents:
+    unknown     = -1
+    mri         = 0
+    label       = 1
+    shape       = 2
+    warpmap     = 3
+    warpmap_inv = 4
+
+
 class FramedArray:
 
     def __init__(self, basedim, data, labels=None, metadata=None):
@@ -264,7 +276,8 @@ class FramedArray:
         """
         pass
 
-    def save(self, filename, fmt=None):
+    # optional parameter to specify FramedArray intent, default is MRI data
+    def save(self, filename, fmt=None, intent=FramedArrayIntents.mri):
         """
         Write array to file.
 
@@ -276,7 +289,7 @@ class FramedArray:
             Optional file format to force.
         """
         from surfa.io.framed import save_framed_array
-        save_framed_array(self, filename, fmt=fmt)
+        save_framed_array(self, filename, fmt=fmt, intent=intent)
 
     def min(self, nonzero=False, frames=False):
         """

--- a/surfa/io/fsio.py
+++ b/surfa/io/fsio.py
@@ -17,8 +17,13 @@ class tags:
     gcamorph_geom = 10
     gcamorph_type = 11
     gcamorph_labels = 12
+    gcamorph_meta = 13    # introduced for mgz warpfield
+    gcamorph_affine = 14  # introduced for mgz warpfield (m3z outputs the same information under xform)
     old_surf_geom = 20
     surf_geom = 21
+    surf_dataspace = 22   # surface tag - surface [x y z] space
+    surf_matrixdata = 23  # surface tag - transform matrix going from surf_dataspace to surf_transformedspace
+    surf_transformedspace = 24  # surface tag - surface [x y z] space after applying the transform matrix
     old_xform = 30
     xform = 31
     group_avg_area = 32
@@ -27,14 +32,22 @@ class tags:
     pedir = 41
     mri_frame = 42
     fieldstrength = 43
+    orig_ras2vox  = 44   # ???
 
 
 # these are FreeSurfer tags that have a
 # buffer with hardcoded length
+# notes:
+# 1. there seems to be some special handling of 'old_xform' for backwards compatibility
+# 2. 'xform' is used in both m3z and mgz, but with different formats.
+#    it is lengthless for m3z, but it has a data-length for mgz
 lengthless_tags = [
     tags.old_surf_geom,
     tags.old_real_ras,
     tags.old_colortable,
+    tags.gcamorph_geom,
+    tags.gcamorph_type,
+    tags.gcamorph_labels
 ]
 
 

--- a/surfa/io/utils.py
+++ b/surfa/io/utils.py
@@ -98,3 +98,68 @@ def write_bytes(file, value, dtype):
         Datatype to save as.
     """
     file.write(np.asarray(value).astype(dtype, copy=False).tobytes())
+
+
+# read VOL_GEOM
+# also see VOL_GEOM.read() in mri.h 
+def read_volgeom(file):
+    volgeom = dict(
+        valid  = read_bytes(file, '>i4', 1),
+                        
+        width  = read_bytes(file, '>i4', 1),
+        height = read_bytes(file, '>i4', 1),
+        depth  = read_bytes(file, '>i4', 1),
+                       
+        xsize  = read_bytes(file, '>f4', 1),
+        ysize  = read_bytes(file, '>f4', 1),
+        zsize  = read_bytes(file, '>f4', 1),
+                        
+        x_r    = read_bytes(file, '>f4', 1),
+        x_a    = read_bytes(file, '>f4', 1),
+        x_s    = read_bytes(file, '>f4', 1),
+        y_r    = read_bytes(file, '>f4', 1),
+        y_a    = read_bytes(file, '>f4', 1),
+        y_s    = read_bytes(file, '>f4', 1),
+        z_r    = read_bytes(file, '>f4', 1),
+        z_a    = read_bytes(file, '>f4', 1),
+        z_s    = read_bytes(file, '>f4', 1),
+                        
+        c_r    = read_bytes(file, '>f4', 1),
+        c_a    = read_bytes(file, '>f4', 1),
+        c_s    = read_bytes(file, '>f4', 1),
+
+        fname  = file.read(512).decode('utf-8').rstrip('\x00')
+        )
+    return volgeom
+
+
+# output VOL_GEOM
+# also see VOL_GEOM.write() in mri.h
+def write_volgeom(file, volgeom):
+    write_bytes(file, volgeom['valid'], '>i4')
+                        
+    write_bytes(file, volgeom['width'], '>i4')
+    write_bytes(file, volgeom['height'], '>i4')
+    write_bytes(file, volgeom['depth'], '>i4')
+                       
+    write_bytes(file, volgeom['xsize'], '>f4')
+    write_bytes(file, volgeom['ysize'], '>f4')
+    write_bytes(file, volgeom['zsize'], '>f4')
+                        
+    write_bytes(file, volgeom['x_r'], '>f4')
+    write_bytes(file, volgeom['x_a'], '>f4')
+    write_bytes(file, volgeom['x_s'], '>f4')
+    write_bytes(file, volgeom['y_r'], '>f4')
+    write_bytes(file, volgeom['y_a'], '>f4')
+    write_bytes(file, volgeom['y_s'], '>f4')
+    write_bytes(file, volgeom['z_r'], '>f4')
+    write_bytes(file, volgeom['z_a'], '>f4')
+    write_bytes(file, volgeom['z_s'], '>f4')
+
+    write_bytes(file, volgeom['c_r'], '>f4')
+    write_bytes(file, volgeom['c_a'], '>f4')
+    write_bytes(file, volgeom['c_s'], '>f4')
+
+    # output 512 bytes padded with '/x00'
+    file.write(volgeom['fname'].ljust(512, '\x00').encode('utf-8'))
+


### PR DESCRIPTION
  Freesurfer now supports mgz warp file, which follows mgz format with these tags and data:
     TAG_GCAMORPH_GEOM   : gcamorph image (source) geom & gcamorph atlas (target) geom
     TAG_GCAMORPH_META   : data format (int), spacing (int), exp_k (double)
     TAG_GCAMORPH_LABELS : gcamorph label data
     TAG_GCAMORPH_AFFINE : gcamorph m_affine matrix
  The version number in mgz is now intent encoded:
     version = (intent & 0xff ) << 8) | MGH_VERSION
     MGH_VERSION = 1

  Changes included in this commit:
  1. add read/write TAG_GCAMORPH_GEOM and TAG_GCAMORPH_META in Surfa MGHArrayIO class
  2. retrieve intent when MGHArrayIO::load(), encode intent in version number when MGHArrayIO:save()
  3. mgz warp related information is saved as the following fields in the FramedArray _metadata dict: intent, gcamorph_volgeom_src, gcamorph_volgeom_trg, warpfield_dtfmt, gcamorph_spacing, gcamorph_exp_k