### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,3 @@
 [build-system]
-requires = ['setuptools', 'wheel', 'Cython', 'numpy']
+# Pinning numpy version to <2.0 due to Numpy 2.0's backwards incompatibility
+requires = ['setuptools', 'wheel', 'Cython', 'numpy<2.0']


### PR DESCRIPTION
Numpy 2.0 has some breaking changes that breaks the installation of Surfa with Python > v3.9