### PR TITLE
Windows 11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 
 import re
 import pathlib
+import platform
 
 from setuptools import setup
 from setuptools import dist
@@ -32,11 +33,15 @@ base_dir = pathlib.Path(__file__).parent.resolve()
 # we don't want to require cython for package install from
 # source distributions, like pypi installs, and the best way I
 # can think of to detect this is by checking if PKG-INFO exists
-cython_build = not base_dir.joinpath('PKG-INFO').is_file()
+cython_build = not base_dir.joinpath('PKG-INFO').is_file() or (platform.system() == 'Windows')
 
 # configure c extensions
 ext = 'pyx' if cython_build else 'c'
-ext_opts = dict(extra_compile_args=['-O3', '-std=c99'])
+if platform.system() == 'Windows':
+    ext_opts = dict(extra_compile_args=['/O2', '/std:c++17'])
+else:
+    ext_opts = dict(extra_compile_args=['-O3', '-std=c99'])
+
 extensions = [
     Extension('surfa.image.interp', [f'surfa/image/interp.{ext}'], **ext_opts),
     Extension('surfa.mesh.intersection', [f'surfa/mesh/intersection.{ext}'], **ext_opts),

--- a/surfa/image/interp.pyx
+++ b/surfa/image/interp.pyx
@@ -88,7 +88,7 @@ def interpolate(source, target_shape, method, affine=None, disp=None, fill=0):
     interp_func = globals().get(f'interp_3d_{order}_{method}')
 
     # speeds up if conditionals are computed outside of function (TODO is this even true?)
-    shape = np.asarray(target_shape).astype('int64')
+    shape = np.asarray(target_shape).astype(np.int_)
 
     # ensure correct byteorder
     # TODO maybe this should be done at read-time?


### PR DESCRIPTION
Surfa was almost working out of the box on Windows 11 with Python 12 and the Visual Studio 2022 compiler (MSVC 22).
I modified setup.py to use MSVC flags. I also fixed one dtype issue in interp.pyx
There may be more issues, but this was enough to let me use mri_synthstrip.