### PR TITLE
Added flag to Freeview to allow the user to skip the check to call FV with vglrun

### DIFF
--- a/surfa/vis/freeview.py
+++ b/surfa/vis/freeview.py
@@ -12,7 +12,7 @@ from surfa.mesh import cast_overlay
 
 class Freeview:
 
-    def __init__(self, title=None, debug=False):
+    def __init__(self, title=None, debug=False, use_vglrun=True):
         """
         A visualization class that wraps the `freeview` command.
 
@@ -31,6 +31,7 @@ class Freeview:
         self.debug = debug
         self.title = title
         self.isshown = False
+        self.use_vglrun = use_vglrun
         self.arguments = []
 
         # first check if freeview is even accessible
@@ -188,9 +189,10 @@ class Freeview:
 
         # freeview can be buggy when run remotely, so let's test if VGL is
         # available to wrap the process
-        vgl = _find_vgl()
-        if vgl is not None:
-            command = f'{vgl} {command}'
+        if self.use_vglrun:
+            vgl = _find_vgl()
+            if vgl is not None:
+                command = f'{vgl} {command}'
 
         # set number of OMP threads if provided
         if threads is not None:


### PR DESCRIPTION
By default, the show() method would check to see if vglrun was installed, and if it did, wrap the FV command in a call to vglrun to help with the remote graphics forwarding. The functionality that tests for vglrun on the system has some hard coded paths that will find vglrun for users at the center even if it is not in their system path. 
Added the use_vglrun flag to the Freeview constructor, if this is set to false, the check for vglrun will not happen, however, setting this to true doesn't necessarily guarantee that FV will be wrapped in a call to vglrun