### PR TITLE
Add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "[dependabot]"
+    cooldown:
+      default-days: 7

--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -1,0 +1,4 @@
+changelog:
+  exclude:
+    authors:
+      - dependabot[bot]


### PR DESCRIPTION
It's recommended to use `dependabot` to get updates to actions like `checkout` (which is now on v6 and this repo [uses v4](https://github.com/freesurfer/surfa/blob/master/.github/workflows/test.yml#L18) for example), to get bugfixes, security updates, etc. It's also useful for lower-event repos (like I maintain for OpenMEEG with stuff like https://github.com/openmeeg/openmeeg/pull/791) just as a reminder that everything is still green. This adds a basic `dependabot` config that I use in many repos, plus a `release.yml` that will exclude the dependabot PRs from the auto-generated release notes if you ever decide to use GitHub releases.