### PR TITLE
fix read-only data array

### DIFF
--- a/surfa/io/utils.py
+++ b/surfa/io/utils.py
@@ -86,7 +86,16 @@ def read_bytes(file, dtype, count=1):
         The read dtype array.
     """
     dtype = np.dtype(dtype)
-    value = np.frombuffer(file.read(dtype.itemsize * count), dtype=dtype)
+
+    # numpy.frombuffer() creates a read-only array if the input buffer is immutable
+    # to get a writable array
+    # 1. create a mutable buffer (bytearray) of a specific size
+    buffer_size = dtype.itemsize * count
+    buf = bytearray(buffer_size)
+    file.readinto(buf)
+
+    # 2. pass the mutable buffer to frombuffer
+    value = np.frombuffer(buf, dtype=dtype)
     if count == 1:
         return value[0]
     return value


### PR DESCRIPTION
  - numpy.frombuffer() creates a read-only array if the input buffer is immutable
  - fix:
    1. create a mutable buffer (bytearray) of a specific size
    2. pass the mutable buffer to frombuffer