### PR TITLE
fix numpy 2.0 int32 scalars to_bytes() error

### DIFF
--- a/surfa/io/utils.py
+++ b/surfa/io/utils.py
@@ -64,7 +64,9 @@ def write_int(file, value, size=4, signed=True, byteorder='big'):
     byteorder : str
         Memory byte order.
     """
-    file.write(value.to_bytes(size, byteorder=byteorder, signed=signed))
+    # to avoid 'AttributeError: 'numpy.int32' object has no attribute 'to_bytes'' in numpy 2.0,
+    # cast numpy.int32 to a native Python int
+    file.write(int(value).to_bytes(size, byteorder=byteorder, signed=signed))
 
 
 def read_bytes(file, dtype, count=1):


### PR DESCRIPTION
  - in NumPy 2.0, int32 scalars to_bytes() fails with 'AttributeError: 'numpy.int32' object has no attribute 'to_bytes''
  - this is because of stricter handling of types in Numpy 2.0 than NumPy 1.x
  - cast numpy.int32 to a native Python int before calling to_bytes()