### PR TITLE
fix surfa.Volume.resample_like() numpy2.0 error

### DIFF
--- a/surfa/image/interp.pyx
+++ b/surfa/image/interp.pyx
@@ -93,8 +93,9 @@ def interpolate(source, target_shape, method, affine=None, disp=None, fill=0):
     # ensure correct byteorder
     # TODO maybe this should be done at read-time?
     swap_byteorder = sys.byteorder == 'little' and '>' or '<'
-    source = source.byteswap().newbyteorder() if source.dtype.byteorder == swap_byteorder else source
-
+    if (source.dtype.byteorder == swap_byteorder):
+       source = source.byteswap().view(source.dtype.newbyteorder())
+    
     # a few types aren't supported, so let's just convert to float and convert back if necessary
     unsupported_dtype = None
     if source.dtype in (np.bool_,):


### PR DESCRIPTION
  - ndarray.newbyteorder method was removed in NumPy 2.0
  - instead of arr.newbyteorder(order), use arr.view(arr.dtype.newbyteorder(order))