### PR TITLE
Fix [0,0,0] "bullet hole" artefact in spherical barycentric resampling

### DIFF
--- a/surfa/mesh/sphere.py
+++ b/surfa/mesh/sphere.py
@@ -113,7 +113,7 @@ def spherical_to_cartesian(points):
     return np.stack([x, y, z], axis=1)
 
 
-def barycentric_spherical_map(source, target, neighborhood=10):
+def barycentric_spherical_map(source, target, neighborhood=30):
     """
     Map the points of a target sphere to the barycentric coordinates of the nearest
     triangle on a source sphere.
@@ -125,7 +125,7 @@ def barycentric_spherical_map(source, target, neighborhood=10):
     target : Mesh
         Target sphere mesh.
     neighborhood : int, optional
-        Max number of nearest triangles to consider for each target point.
+        Max number of nearest triangles to consider for each target point. 
 
     Returns
     -------
@@ -214,12 +214,12 @@ def barycentric_spherical_map(source, target, neighborhood=10):
         intersecting_faces[remaining] = faces[hits]
         intersecting_barycenters[remaining] = barycentric[hits]
 
-    # if any target points were not assigned a face, just assign them the
-    # center of the nearest face
-    if np.count_nonzero(remaining) != 0:
-        missing = intersecting_faces == -1
+    # If any target points were not assigned a face, 
+    # fall back to the nearest face (barycentric centroid).
+    missing = intersecting_faces == -1
+    if np.count_nonzero(missing) != 0:
         intersecting_faces[missing] = nearest[0][missing]
-        intersecting_barycenters[missing] = 0.33333333
+        intersecting_barycenters[missing] = 1.0 / 3.0
 
     return intersecting_faces, intersecting_barycenters
 


### PR DESCRIPTION
## Summary
`barycentric_spherical_map()` can leave a few target vertices unmapped, which
collapses their interpolated value to **exactly `[0, 0, 0]`**. When the map is
used to resample mesh *coordinates* (e.g. white/pial surfaces onto a canonical
topology), the affected vertices are teleported to the origin and their 1-ring
neighbours are stretched by tens of millimetres — a "bullet hole" in the surface.

## Root cause (two compounding bugs)
1. **Search neighbourhood too small.** Only the `neighborhood` (=10) nearest
   source-triangle *centroids* are searched per target point. Registration
   (e.g. `mris_register`) can distort triangle areas by >200× on the sphere,
   pushing a target point's true containing triangle past the nearest 10
   centroids (observed rank **11–12**), so it is never found.
2. **Fallback guard tests the wrong mask.** The "assign unmatched points to the
   nearest face" fallback was guarded by `np.count_nonzero(remaining)`, where
   `remaining` is the leftover mask from the *final* loop iteration, not "are any
   points still unassigned". When the last iteration matched nothing, the
   fallback was skipped and those points kept `face == -1` with zero weights.
3. **Consequence.** `SphericalResamplingBarycentric` then does `source.faces[faces]`
   with `faces == -1`, so NumPy negative-indexes the *last* face, and the zero
   weights make `sample()` return exactly `[0, 0, 0]`.

## Fix
- `barycentric_spherical_map` default `neighborhood` 10 → 30 (negligible cost; the
  correct containing triangle is found, giving exact barycentric weights).
- Guard the fallback on the actual `intersecting_faces == -1` mask so it always
  runs — no point can be left with a `-1` face / zero weights.
