### PR TITLE
NumPy 2.x compatibility fixes for image interpolation and I/O

### DIFF
--- a/surfa/image/framed.py
+++ b/surfa/image/framed.py
@@ -509,8 +509,18 @@ class FramedImage(FramedArray):
         for i in range(self.basedim):
             if world_axes_src[i] != world_axes_trg[i]:
                 data = np.swapaxes(data, world_axes_src[i], world_axes_trg[i])
-                swapped_axis_idx = np.where(world_axes_src == world_axes_trg[i])
-                world_axes_src[swapped_axis_idx], world_axes_src[i] = world_axes_src[i], world_axes_src[swapped_axis_idx]
+                # NumPy 2.x no longer supports mixed scalar/sequence tuple-assignment
+                # with np.where tuple indexing here, so resolve a scalar index first.
+                swapped_axis_idx = np.where(world_axes_src == world_axes_trg[i])[0]
+                if swapped_axis_idx.size == 0:
+                    raise RuntimeError(
+                        "Failed to resolve source axis during reorientation."
+                    )
+                swapped_axis = int(swapped_axis_idx[0])
+                world_axes_src[swapped_axis], world_axes_src[i] = (
+                    world_axes_src[i],
+                    world_axes_src[swapped_axis],
+                )
 
         # align directions
         dot_products = np.sum(affine[:3, :3] * trg_matrix[:3, :3], axis=0)

--- a/surfa/image/interp.pyx
+++ b/surfa/image/interp.pyx
@@ -93,9 +93,10 @@ def interpolate(source, target_shape, method, affine=None, disp=None, fill=0):
     # ensure correct byteorder
     # TODO maybe this should be done at read-time?
     swap_byteorder = sys.byteorder == 'little' and '>' or '<'
-    if (source.dtype.byteorder == swap_byteorder):
-       source = source.byteswap().view(source.dtype.newbyteorder())
-    
+    if source.dtype.byteorder == swap_byteorder:
+        # NumPy 2 removed ndarray.newbyteorder(); use a dtype view instead.
+        source = source.byteswap().view(source.dtype.newbyteorder('='))
+
     # a few types aren't supported, so let's just convert to float and convert back if necessary
     unsupported_dtype = None
     if source.dtype in (np.bool_,):

--- a/surfa/io/framed.py
+++ b/surfa/io/framed.py
@@ -2,6 +2,14 @@ import warnings
 import gzip
 import numpy as np
 
+# NumPy compatibility: handle np.bool_ removal in NumPy 2.0
+# In NumPy 1.x, np.bool_ is the proper numpy boolean type
+# In NumPy 2.x, np.bool_ was removed and np.bool is the scalar type
+if hasattr(np, 'bool_'):
+    _np_bool_dtype = np.bool_  # NumPy 1.x
+else:
+    _np_bool_dtype = np.bool   # NumPy 2.x
+
 from surfa import Volume
 from surfa import Slice
 from surfa import Overlay
@@ -407,7 +415,7 @@ class MGHArrayIO(protocol.IOProtocol):
 
             # determine supported dtype to save as (order here is very important)
             type_map = {
-                np.bool_: 0,
+                _np_bool_dtype: 0,
                 np.uint8: 0,
                 np.int32: 1,
                 np.floating: 3,
@@ -670,7 +678,7 @@ class NiftiArrayIO(protocol.IOProtocol):
 
         # convert to a valid output type (for now this is only bool but there are probably more)
         type_map = {
-            np.bool_: np.uint8,
+            _np_bool_dtype: np.uint8,
         }
         dtype_id = next((i for dt, i in type_map.items() if np.issubdtype(arr.dtype, dt)), None)
         data = arr.data if dtype_id is None else arr.data.astype(dtype_id)

--- a/surfa/io/framed.py
+++ b/surfa/io/framed.py
@@ -2,9 +2,8 @@ import warnings
 import gzip
 import numpy as np
 
-# NumPy compatibility: handle np.bool_ removal in NumPy 2.0
-# In NumPy 1.x, np.bool_ is the proper numpy boolean type
-# In NumPy 2.x, np.bool_ was removed and np.bool is the scalar type
+# NumPy compatibility: prefer the numpy boolean scalar dtype object.
+# `np.bool_` exists in both NumPy 1.x and 2.x; keep a fallback for safety.
 if hasattr(np, 'bool_'):
     _np_bool_dtype = np.bool_  # NumPy 1.x
 else:

--- a/surfa/io/fsnifti1extension.py
+++ b/surfa/io/fsnifti1extension.py
@@ -1,5 +1,13 @@
 import numpy as np
 
+# NumPy compatibility: handle np.int_ removal in NumPy 2.0
+# In NumPy 1.x, np.int_ is an alias for the platform's native int type
+# In NumPy 2.x, np.int_ was removed; use np.integer for type checking
+if hasattr(np, 'int_'):
+    _np_int_types = (np.int_, np.integer)  # NumPy 1.x: check both for safety
+else:
+    _np_int_types = (np.integer,)          # NumPy 2.x: only np.integer exists
+
 from surfa.io import fsio
 from surfa.io import utils as iou
 from surfa.transform.geometry import ImageGeometry
@@ -566,7 +574,7 @@ class FSNifti1Extension:
             self.version = 1
             self.intent = image.metadata.get('intent', FramedArrayIntents.mri)
             self.dof = 1
-            if isinstance(self.intent, np.int_):
+            if isinstance(self.intent, _np_int_types):
                 self.intent = self.intent.item()  # convert numpy int to python int
 
             if self.intent == FramedArrayIntents.warpmap:

--- a/test/test_numpy_compat.py
+++ b/test/test_numpy_compat.py
@@ -1,0 +1,46 @@
+import sys
+
+import numpy as np
+import pytest
+
+
+sf = pytest.importorskip('surfa')
+
+
+def _non_native_float32(data):
+    byteorder = '>' if sys.byteorder == 'little' else '<'
+    return np.asarray(data, dtype=np.float32).astype(np.dtype(np.float32).newbyteorder(byteorder), copy=True)
+
+
+def _assert_machine_precision_equal(a, b):
+    assert a.shape == b.shape
+    assert a.dtype == b.dtype
+    assert np.issubdtype(a.dtype, np.floating)
+
+    scale = max(
+        float(np.max(np.abs(a))),
+        float(np.max(np.abs(b))),
+        1.0,
+    )
+    atol = np.finfo(a.dtype).eps * scale
+    assert np.allclose(a, b, rtol=0.0, atol=atol), f'max abs diff={np.max(np.abs(a - b))}, atol={atol}'
+
+
+@pytest.mark.parametrize('method', ['linear', 'nearest'])
+def test_resize_non_native_endian_matches_native(method):
+    rng = np.random.default_rng(123456)
+    data_native = rng.normal(loc=0.1, scale=1.7, size=(9, 7, 5, 2)).astype(np.float32)
+    data_non_native = _non_native_float32(data_native)
+
+    vol_native = sf.Volume(data_native)
+    vol_non_native = sf.Volume(data_non_native)
+
+    assert vol_non_native.framed_data.dtype.byteorder not in ('=', '|')
+
+    voxsize = np.array([1.3, 0.9, 1.7], dtype=np.float32)
+    resized_native = vol_native.resize(voxsize, method=method)
+    resized_non_native = vol_non_native.resize(voxsize, method=method)
+
+    assert resized_native.framed_data.shape == resized_non_native.framed_data.shape
+    assert resized_native.framed_data.dtype == resized_non_native.framed_data.dtype
+    _assert_machine_precision_equal(resized_native.framed_data, resized_non_native.framed_data)


### PR DESCRIPTION
## Summary

This PR updates Surfa for NumPy 2.x compatibility while preserving NumPy 1.x behavior.

Changes include:
- Replaces removed/fragile NumPy byte-order handling in image interpolation with a `byteswap().view(dtype.newbyteorder('='))` path.
- Fixes image reorientation axis bookkeeping to avoid NumPy 2.x tuple/scalar assignment behavior changes.
- Adds compatibility handling for NumPy boolean and integer scalar dtypes in framed I/O and FreeSurfer NIfTI extension metadata.
- Updates build configuration:
  - makes abi3 wheel building opt-in via `SURFA_ABI3=1`
  - fixes `package_data` so both `.pyx` and `.h` files are included.
- Adds a regression test ensuring non-native-endian image data resizes identically to native-endian data for both linear and nearest interpolation.

## Testing

Added `test/test_numpy_compat.py` covering native vs non-native endian resize behavior.